### PR TITLE
fix：系统定时任务持久化

### DIFF
--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/mapper/JobsMapper.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/mapper/JobsMapper.java
@@ -14,6 +14,5 @@ import java.util.List;
  */
 @Mapper
 public interface JobsMapper extends BaseMapper<Jobs> {
-    @Select("select * from jobs where type = #{type}")
-    Jobs findByType(@Param("type") String type);
+
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/mapper/JobsMapper.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/mapper/JobsMapper.java
@@ -2,7 +2,11 @@ package org.cloud.sonic.controller.mapper;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
 import org.cloud.sonic.controller.models.domain.Jobs;
+
+import java.util.List;
 
 /**
  *  Mapper 接口
@@ -10,5 +14,6 @@ import org.cloud.sonic.controller.models.domain.Jobs;
  */
 @Mapper
 public interface JobsMapper extends BaseMapper<Jobs> {
-
+    @Select("select * from jobs where type = #{type}")
+    Jobs findByType(@Param("type") String type);
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/domain/Jobs.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/domain/Jobs.java
@@ -54,4 +54,8 @@ public class Jobs implements Serializable, TypeConverter<Jobs, JobsDTO> {
     @TableField
     @Column(value = "suite_id", isNull = false, comment = "测试套件id")
     private Integer suiteId;
+
+    @TableField
+    @Column(isNull = false, comment = "定时任务类型")
+    private String type;
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/quartz/QuartzHandler.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/quartz/QuartzHandler.java
@@ -17,6 +17,7 @@
 package org.cloud.sonic.controller.quartz;
 
 import com.alibaba.fastjson.JSONObject;
+import org.cloud.sonic.controller.mapper.JobsMapper;
 import org.cloud.sonic.controller.models.domain.Jobs;
 import org.cloud.sonic.controller.models.interfaces.JobType;
 import org.quartz.*;
@@ -39,6 +40,8 @@ public class QuartzHandler {
     private final Logger logger = LoggerFactory.getLogger(QuartzHandler.class);
     @Autowired
     private Scheduler scheduler;
+    @Autowired
+    private JobsMapper jobsMapper;
     private List<String> typeList = Arrays.asList("cleanFile", "cleanResult", "sendDayReport", "sendWeekReport");
 
     /**
@@ -246,7 +249,30 @@ public class QuartzHandler {
 
     public void createSysTrigger() {
         for (String type : typeList) {
-            updateSysScheduleJob(type, "");
+//            从数据库中获取数据，然后创建
+            Jobs job = jobsMapper.findByType(type);
+//            首次部署，初始化系统定时任务
+            if (job == null) {
+                initSysJob(job, type);
+            }
+            updateSysScheduleJob(type, job.getCronExpression());
         }
+    }
+
+    /**
+     * 初始化系统定时任务
+     * @param job jobs 表实体
+     * @param type 系统定时任务类型
+     */
+    private void initSysJob(Jobs job, String type) {
+        String name = "";
+        String cronExpression = "";
+
+        job.setCronExpression(cronExpression);
+        job.setName(name);
+        job.setProjectId(0);
+        job.setStatus(1);
+        job.setSuiteId(0);
+        job.setType(type);
     }
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/quartz/QuartzHandler.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/quartz/QuartzHandler.java
@@ -268,6 +268,25 @@ public class QuartzHandler {
         String name = "";
         String cronExpression = "";
 
+        switch (type) {
+            case "cleanFile":
+                cronExpression = "0 0 12 15 * ?";
+                name = "清理系统文件";
+                break;
+            case "cleanResult":
+                cronExpression = "0 0 12 15 * ?";
+                name = "清理测试报告";
+                break;
+            case "sendDayReport":
+                cronExpression = "0 0 10 * * ?";
+                name = "发送日报";
+                break;
+            case "sendWeekReport":
+                cronExpression = "0 0 10 ? * MON";
+                name = "发送周报";
+                break;
+        }
+
         job.setCronExpression(cronExpression);
         job.setName(name);
         job.setProjectId(0);

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/quartz/QuartzHandler.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/quartz/QuartzHandler.java
@@ -20,6 +20,7 @@ import com.alibaba.fastjson.JSONObject;
 import org.cloud.sonic.controller.mapper.JobsMapper;
 import org.cloud.sonic.controller.models.domain.Jobs;
 import org.cloud.sonic.controller.models.interfaces.JobType;
+import org.cloud.sonic.controller.services.JobsService;
 import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +42,7 @@ public class QuartzHandler {
     @Autowired
     private Scheduler scheduler;
     @Autowired
-    private JobsMapper jobsMapper;
+    private JobsService jobsService;
     private List<String> typeList = Arrays.asList("cleanFile", "cleanResult", "sendDayReport", "sendWeekReport");
 
     /**
@@ -250,7 +251,7 @@ public class QuartzHandler {
     public void createSysTrigger() {
         for (String type : typeList) {
 //            从数据库中获取数据，然后创建
-            Jobs job = jobsMapper.findByType(type);
+            Jobs job = jobsService.findByType(type);
 //            首次部署，初始化系统定时任务
             if (job == null) {
                 initSysJob(job, type);

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/JobsService.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/JobsService.java
@@ -25,6 +25,8 @@ public interface JobsService extends IService<Jobs> {
 
     Jobs findById(int id);
 
+    Jobs findByType(String type);
+
     void updateSysJob(String type,String cron);
 
     List<JSONObject> findSysJobs();

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/JobsServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/JobsServiceImpl.java
@@ -50,12 +50,13 @@ public class JobsServiceImpl extends SonicServiceImpl<JobsMapper, Jobs> implemen
     private QuartzHandler quartzHandler;
     @Autowired
     private JobsMapper jobsMapper;
+    private static final String TEST_JOB = "testJob";
 
     @Override
     @Transactional(rollbackFor = Exception.class)
     public RespModel<String> saveJobs(Jobs jobs) throws SonicException {
         jobs.setStatus(JobStatus.ENABLE);
-        jobs.setType("TEST_JOB");
+        jobs.setType(TEST_JOB);
         save(jobs);
         CronTrigger trigger = quartzHandler.getTrigger(jobs);
         try {
@@ -122,7 +123,7 @@ public class JobsServiceImpl extends SonicServiceImpl<JobsMapper, Jobs> implemen
     public Page<Jobs> findByProjectId(int projectId, Page<Jobs> pageable) {
         return lambdaQuery()
                 .eq(Jobs::getProjectId, projectId)
-                .eq(Jobs::getType, "TEST_JOB")
+                .eq(Jobs::getType, TEST_JOB)
                 .orderByDesc(Jobs::getId)
                 .page(pageable);
     }
@@ -131,9 +132,17 @@ public class JobsServiceImpl extends SonicServiceImpl<JobsMapper, Jobs> implemen
     public Jobs findById(int id) {
         return lambdaQuery()
                 .eq(Jobs::getId, id)
-                .eq(Jobs::getType, "TEST_JOB")
+                .eq(Jobs::getType, TEST_JOB)
                 .one();
     }
+
+    @Override
+    public Jobs findByType(String type) {
+        return lambdaQuery()
+                .eq(Jobs::getType, type)
+                .one();
+    }
+
 
     @Override
     public void updateSysJob(String type, String cron) {

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/JobsServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/JobsServiceImpl.java
@@ -18,6 +18,7 @@ package org.cloud.sonic.controller.services.impl;
 
 import com.alibaba.fastjson.JSONObject;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.ibatis.util.MapUtil;
 import org.cloud.sonic.common.exception.SonicException;
 import org.cloud.sonic.common.http.RespEnum;
 import org.cloud.sonic.common.http.RespModel;
@@ -33,7 +34,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.cloud.sonic.controller.quartz.QuartzHandler;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author ZhouYiXun
@@ -52,6 +55,7 @@ public class JobsServiceImpl extends SonicServiceImpl<JobsMapper, Jobs> implemen
     @Transactional(rollbackFor = Exception.class)
     public RespModel<String> saveJobs(Jobs jobs) throws SonicException {
         jobs.setStatus(JobStatus.ENABLE);
+        jobs.setType("TEST_JOB");
         save(jobs);
         CronTrigger trigger = quartzHandler.getTrigger(jobs);
         try {
@@ -118,17 +122,29 @@ public class JobsServiceImpl extends SonicServiceImpl<JobsMapper, Jobs> implemen
     public Page<Jobs> findByProjectId(int projectId, Page<Jobs> pageable) {
         return lambdaQuery()
                 .eq(Jobs::getProjectId, projectId)
+                .eq(Jobs::getType, "TEST_JOB")
                 .orderByDesc(Jobs::getId)
                 .page(pageable);
     }
 
     @Override
     public Jobs findById(int id) {
-        return baseMapper.selectById(id);
+        return lambdaQuery()
+                .eq(Jobs::getId, id)
+                .eq(Jobs::getType, "TEST_JOB")
+                .one();
     }
 
     @Override
     public void updateSysJob(String type, String cron) {
+        Jobs jobs =  lambdaQuery()
+                .eq(Jobs::getType, type)
+                .one();
+        if(jobs != null){
+            jobs.setCronExpression(cron);
+            save(jobs);
+        }
+
         quartzHandler.updateSysScheduleJob(type, cron);
     }
 


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（保存后请点击复选框）：**

- [x] 标题为fix、feat或doc开头
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**
1、jobs 表添加 type 字段用于区分系统/非系统定时任务，需要对原来的非系统定时任务做下处理
- ALTER TABLE jobs ADD `type` VARCHAR(20) 
- UPDATE jobs SET `type` = 'TEST_JOB' WHERE `type` is null

2、定时任务相关的接口根据 `type` 字段进行了过滤
3、系统定时任务保存到 jobs 表中，初始化系统定时任务时，从表中取 cron 表达式
4、如果表中没有系统定时任务，会初始化进去