### PR TITLE
feat: support extra global params per testsuite

### DIFF
--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/mapper/TestSuitesGlobalParamsMapper.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/mapper/TestSuitesGlobalParamsMapper.java
@@ -1,0 +1,15 @@
+package org.cloud.sonic.controller.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
+import org.cloud.sonic.controller.models.domain.TestSuitesGlobalParams;
+
+/**
+ * Mapper 接口
+ *
+ * @author mmagi
+ * @since 2023-03-25
+ */
+@Mapper
+public interface TestSuitesGlobalParamsMapper extends BaseMapper<TestSuitesGlobalParams> {
+}

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/domain/TestSuitesGlobalParams.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/domain/TestSuitesGlobalParams.java
@@ -1,0 +1,47 @@
+package org.cloud.sonic.controller.models.domain;
+
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableName;
+import com.gitee.sunchenbin.mybatis.actable.annotation.*;
+import com.gitee.sunchenbin.mybatis.actable.constants.MySqlCharsetConstant;
+import com.gitee.sunchenbin.mybatis.actable.constants.MySqlEngineConstant;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import org.cloud.sonic.controller.models.base.TypeConverter;
+import org.cloud.sonic.controller.models.dto.TestSuitesGlobalParamsDTO;
+
+import java.io.Serializable;
+
+/**
+ * @author mmagi
+ * @since 2023-03-25
+ */
+@Schema(name ="TestSuitesGlobalParams对象", description = "")
+@Data
+@Accessors(chain = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@TableName("test_suites_global_params")
+@TableComment("测试套件附加全局参数表")
+@TableCharset(MySqlCharsetConstant.DEFAULT)
+@TableEngine(MySqlEngineConstant.InnoDB)
+public class TestSuitesGlobalParams implements Serializable, TypeConverter<TestSuitesGlobalParams, TestSuitesGlobalParamsDTO> {
+
+    @TableField
+    @Column(value = "test_suites_id", isNull = false, comment = "测试套件id")
+    @Index(value = "idx_test_suites_id_devices_id", columns = {"test_suites_id", "params_key"})
+    private Integer testSuitesId;
+
+    @TableField
+    @Column(value = "params_key", isNull = false, comment = "参数key")
+    private String paramsKey;
+
+    @TableField
+    @Column(value = "params_value", isNull = false, comment = "参数value")
+    private String paramsValue;
+}

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/dto/TestSuitesDTO.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/dto/TestSuitesDTO.java
@@ -55,4 +55,7 @@ public class TestSuitesDTO implements Serializable, TypeConverter<TestSuitesDTO,
 
     @Schema(description = "指定设备列表")
     List<DevicesDTO> devices;
+
+    @Schema(description = "测试套件附加全局参数")
+    List<TestSuitesGlobalParamsDTO> testSuitesGlobalParams;
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/dto/TestSuitesGlobalParamsDTO.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/dto/TestSuitesGlobalParamsDTO.java
@@ -1,0 +1,36 @@
+package org.cloud.sonic.controller.models.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import org.cloud.sonic.controller.models.base.TypeConverter;
+import org.cloud.sonic.controller.models.domain.TestSuitesGlobalParams;
+
+import java.io.Serializable;
+
+/**
+ * <p>
+ *
+ * </p>
+ *
+ * @author mmagi
+ * @since 2023-03-25
+ */
+@Schema(name = "TestSuitesGlobalParamsDTO 对象", description = "")
+@Data
+@Accessors(chain = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TestSuitesGlobalParamsDTO implements Serializable, TypeConverter<TestSuitesGlobalParamsDTO, TestSuitesGlobalParams> {
+
+    private Integer testSuitesId;
+
+    private String paramsKey;
+
+    private String paramsValue;
+}
+


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description
支持为每个测试套件单独设置全局变量，优先级高于项目整体的全局变量，以便测试用例的复用
前端部分见https://github.com/SonicCloudOrg/sonic-client-web/pull/238
