### PR TITLE
fix:删除单个步骤时，同步删除steps_elements存储的元素-步骤关联记录

### DIFF
--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/StepsServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/StepsServiceImpl.java
@@ -185,6 +185,8 @@ public class StepsServiceImpl extends SonicServiceImpl<StepsMapper, Steps> imple
         if (existsById(id)) {
             Steps steps = baseMapper.selectById(id);
             publicStepsStepsMapper.delete(new QueryWrapper<PublicStepsSteps>().eq("steps_id", steps.getId()));
+            stepsElementsMapper.delete(new LambdaQueryWrapper<StepsElements>().eq(StepsElements::getStepsId,
+                    steps.getId()));
             baseMapper.deleteById(id);
             return true;
         } else {


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

删除单个步骤时， steps_elements表中存储的记录不变。
删除单个元素时，将 steps_elements表 中关联对应element_id相关的记录标记为0。

最终会导致steps_elements 存在较多的无用记录，

可以考虑在删除步骤是，同步的将steps_elements表中存储的记录一并删除掉，避免长期使用累积脏数据的问题。

社区讨论贴：https://sonic-cloud.wiki/d/2899-steps-elements
