### PR TITLE
feat--应用程序面板，增加拉取“持续集成设置”->“安装包管理”中app的能力

### DIFF
--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/controller/PackageController.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/controller/PackageController.java
@@ -59,11 +59,13 @@ public class PackageController {
     public RespModel<CommentPage<PackageDTO>> findAll(@RequestParam(name = "projectId") int projectId,
                                                       @RequestParam(name = "branch", required = false) String branch,
                                                       @RequestParam(name = "platform", required = false) String platform,
+                                                      @RequestParam(name = "packageName", required = false) String packageName,
                                                       @RequestParam(name = "page") int page,
                                                       @RequestParam(name = "pageSize") int pageSize) {
 
         Page<Packages> pageable = new Page<>(page, pageSize);
 
-        return new RespModel<>(RespEnum.SEARCH_OK, packagesService.findByProjectId(projectId, branch, platform, pageable));
+        return new RespModel<>(RespEnum.SEARCH_OK, packagesService.findByProjectId(projectId, branch, platform,
+                packageName, pageable));
     }
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/PackagesService.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/PackagesService.java
@@ -21,5 +21,5 @@ public interface PackagesService extends IService<Packages> {
      *
      * @return
      */
-    CommentPage<PackageDTO> findByProjectId(int projectId, String branch, String platform, Page<Packages> pageable);
+    CommentPage<PackageDTO> findByProjectId(int projectId, String branch, String platform, String packageName, Page<Packages> pageable);
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/PackagesServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/PackagesServiceImpl.java
@@ -55,10 +55,12 @@ public class PackagesServiceImpl extends SonicServiceImpl<PackagesMapper, Packag
     }
 
     @Override
-    public CommentPage<PackageDTO> findByProjectId(int projectId, String branch, String platform, Page<Packages> pageable) {
+    public CommentPage<PackageDTO> findByProjectId(int projectId, String branch, String platform, String packageName,
+                                                   Page<Packages> pageable) {
         Page<Packages> page = lambdaQuery().eq(Packages::getProjectId, projectId)
                 .eq(StringUtils.isNotBlank(platform), Packages::getPlatform, platform)
                 .like(StringUtils.isNotBlank(branch), Packages::getBranch, branch)
+                .like(StringUtils.isNotBlank(packageName), Packages::getPkgName, packageName)
                 .orderByDesc(Packages::getId)
                 .page(pageable);
 
@@ -66,7 +68,5 @@ public class PackagesServiceImpl extends SonicServiceImpl<PackagesMapper, Packag
                 .stream().map(TypeConverter::convertTo).collect(Collectors.toList());
 
         return CommentPage.convertFrom(page, packageDTOList);
-
-
     }
 }


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

应用程序面板，新增加tab，通过选择持续集成安装包管理的方式进行安装。
后端改造：查询安装包的接口调整，增加通过安装包名称来搜索相关结果，配合前端的UI显示。

相关需求细节在社区中简单沟通：https://sonic-cloud.wiki/d/3064-app
