### PR TITLE
fix:删除项目时，有三个关联表的记录未处理，存在脏数据

### DIFF
--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/StepsServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/StepsServiceImpl.java
@@ -300,6 +300,12 @@ public class StepsServiceImpl extends SonicServiceImpl<StepsMapper, Steps> imple
 
     @Override
     public boolean deleteByProjectId(int projectId) {
+        // 先删除steps_elements表中，属于该projectId下的"步骤-元素"关联记录
+        List<Steps> allSteps = stepsMapper.selectList(new LambdaQueryWrapper<Steps>().eq(Steps::getProjectId, projectId));
+        for (Steps curStep : allSteps) {
+            stepsElementsMapper.delete(new LambdaQueryWrapper<StepsElements>().eq(StepsElements::getStepsId, curStep.getId()));
+        }
+        // 再删除指定projectId的Step
         return baseMapper.delete(new LambdaQueryWrapper<Steps>().eq(Steps::getProjectId, projectId)) > 0;
     }
 

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestSuitesServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestSuitesServiceImpl.java
@@ -436,6 +436,16 @@ public class TestSuitesServiceImpl extends SonicServiceImpl<TestSuitesMapper, Te
 
     @Override
     public boolean deleteByProjectId(int projectId) {
+        List<TestSuites> testSuitesList = baseMapper.selectList(
+                new LambdaQueryWrapper<TestSuites>().eq(TestSuites::getProjectId, projectId));
+        for (TestSuites curTestSuites : testSuitesList) {
+            // 先删除 test_suites_test_cases 以及 test_suites_devices 两表中的记录
+            testSuitesTestCasesMapper.delete(new LambdaQueryWrapper<TestSuitesTestCases>()
+                    .eq(TestSuitesTestCases::getTestSuitesId, curTestSuites.getId()));
+            testSuitesDevicesMapper.delete(new LambdaQueryWrapper<TestSuitesDevices>()
+                    .eq(TestSuitesDevices::getTestSuitesId, curTestSuites.getId()));
+        }
+        // 再删除 test_suites 中的记录
         return baseMapper.delete(new LambdaQueryWrapper<TestSuites>().eq(TestSuites::getProjectId, projectId)) > 0;
     }
 

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestSuitesServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestSuitesServiceImpl.java
@@ -443,15 +443,8 @@ public class TestSuitesServiceImpl extends SonicServiceImpl<TestSuitesMapper, Te
     public boolean deleteByProjectId(int projectId) {
         List<TestSuites> testSuitesList = baseMapper.selectList(
                 new LambdaQueryWrapper<TestSuites>().eq(TestSuites::getProjectId, projectId));
-        for (TestSuites curTestSuites : testSuitesList) {
-            // 先删除 test_suites_test_cases 以及 test_suites_devices 两表中的记录
-            testSuitesTestCasesMapper.delete(new LambdaQueryWrapper<TestSuitesTestCases>()
-                    .eq(TestSuitesTestCases::getTestSuitesId, curTestSuites.getId()));
-            testSuitesDevicesMapper.delete(new LambdaQueryWrapper<TestSuitesDevices>()
-                    .eq(TestSuitesDevices::getTestSuitesId, curTestSuites.getId()));
-        }
-        // 再删除 test_suites 中的记录
-        return baseMapper.delete(new LambdaQueryWrapper<TestSuites>().eq(TestSuites::getProjectId, projectId)) > 0;
+        testSuitesList.forEach(curTestSuites -> delete(curTestSuites.getId()));
+        return testSuitesList.size() > 0;
     }
 
     @Override

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestSuitesServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestSuitesServiceImpl.java
@@ -360,6 +360,11 @@ public class TestSuitesServiceImpl extends SonicServiceImpl<TestSuitesMapper, Te
 
     @Override
     public boolean delete(int id) {
+        // 先删除 test_suites_test_cases 以及 test_suites_devices 两表中的记录
+        testSuitesTestCasesMapper.delete(new LambdaQueryWrapper<TestSuitesTestCases>()
+                .eq(TestSuitesTestCases::getTestSuitesId, id));
+        testSuitesDevicesMapper.delete(new LambdaQueryWrapper<TestSuitesDevices>()
+                .eq(TestSuitesDevices::getTestSuitesId, id));
         return baseMapper.deleteById(id) > 0;
     }
 

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestSuitesServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestSuitesServiceImpl.java
@@ -443,8 +443,15 @@ public class TestSuitesServiceImpl extends SonicServiceImpl<TestSuitesMapper, Te
     public boolean deleteByProjectId(int projectId) {
         List<TestSuites> testSuitesList = baseMapper.selectList(
                 new LambdaQueryWrapper<TestSuites>().eq(TestSuites::getProjectId, projectId));
-        testSuitesList.forEach(curTestSuites -> delete(curTestSuites.getId()));
-        return testSuitesList.size() > 0;
+        if (testSuitesList != null && !testSuitesList.isEmpty()) {
+            return testSuitesList.stream()
+                    .map(TestSuites::getId)
+                    .map(this::delete)
+                    .reduce(true, Boolean::logicalAnd);
+        } else {
+            // 如果查询到的list不会null，但是数量为0，说明本身不存在测试套件，直接返回true。
+            return testSuitesList != null;
+        }
     }
 
     @Override


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

[删除步骤时，steps_elements表中的记录未同步删除，是有什么特殊的考虑吗？](https://sonic-cloud.wiki/d/2899-steps-elements)
社区之前讨论的一个问题，我这边整体梳理检查了下，目前项目中存在4个关联映射表：

> public_steps_steps
> steps_elements
> test_suites_test_cases
> test_suites_devices

public_steps_steps 我看已经处理了，另外三个我这次一起都改了，辛苦看看还有遗留没处理的关联表吗。
