### PR TITLE
feat:支持从任意行添加或复制步骤

### DIFF
--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/controller/StepsController.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/controller/StepsController.java
@@ -161,11 +161,13 @@ public class StepsController {
     @Operation(summary = "复制步骤", description = "测试用例复制其中一个步骤")
     @Parameters(value = {
             @Parameter(name = "id", description = "用例中需要被复制步骤Id"),
+            @Parameter(name = "toLast", description = "是否拷贝用例到最后一行", example = "true"),
     })
     @GetMapping("/copy/steps")
-    public RespModel<String> copyStepsIdByCase(@RequestParam(name = "id") int stepId) {
-        stepsService.copyStepsIdByCase(stepId);
-
+    public RespModel<String> copyStepsIdByCase(@RequestParam(name = "id") int stepId,
+                                               @RequestParam(name = "toLast", defaultValue = "true", required = false)
+                                                       boolean toLast) {
+        stepsService.copyStepsIdByCase(stepId, toLast);
         return new RespModel<>(RespEnum.COPY_OK);
     }
 

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/StepsService.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/StepsService.java
@@ -69,7 +69,7 @@ public interface StepsService extends IService<Steps> {
     CommentPage<StepsDTO> searchFindByProjectIdAndPlatform(int projectId, int platform, int page, int pageSize,
                                                            String searchContent);
 
-    Boolean copyStepsIdByCase(Integer stepId);
+    Boolean copyStepsIdByCase(Integer stepId, boolean toLast);
 
     Boolean switchStep(int id, int type);
 

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/StepsService.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/StepsService.java
@@ -74,4 +74,22 @@ public interface StepsService extends IService<Steps> {
     Boolean switchStep(int id, int type);
 
     List<PublicStepsAndStepsIdDTO> stepAndIndex(List<StepsDTO> needAllCopySteps);
+
+    /**
+     * 找到指定用例中最后一个步骤的sort
+     *
+     * @param castId 用例的id
+     * @return 最后一个步骤的sort
+     */
+    Integer findMaxStepSort(int castId);
+
+    /**
+     * 找到指定用例的指定步骤，下一个step的sort值
+     *
+     * @param castId       目标用例
+     * @param targetStepId 目标步骤id
+     * @return 下一个step的sort值
+     */
+    Integer findNextStepSort(int castId, int targetStepId);
+
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/StepsServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/StepsServiceImpl.java
@@ -434,6 +434,30 @@ public class StepsServiceImpl extends SonicServiceImpl<StepsMapper, Steps> imple
         }
     }
 
+    @Override
+    public Integer findMaxStepSort(int castId) {
+        List<Steps> stepsList = lambdaQuery().eq(Steps::getCaseId, castId)
+                .orderByDesc(Steps::getSort)
+                .list();
+        if (stepsList != null && stepsList.size() > 0) {
+            return stepsList.get(0).getSort();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Integer findNextStepSort(int castId, int targetStepId) {
+        List<Steps> stepsList = lambdaQuery().eq(Steps::getCaseId, castId)
+                .orderByAsc(Steps::getSort)
+                .list();
+        for (int i = 0; i < stepsList.size(); i++) {
+            if (stepsList.get(i).getId() == targetStepId) {
+                return i == stepsList.size() - 1 ? null : stepsList.get(i + 1).getSort();
+            }
+        }
+        return null;
+    }
 
     /**
      * 记录一组步骤中他们所在的位置；ma


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description
需求背景：当前在sonic中新增步骤，或者复制步骤，默认都是添加到最后一步，再通过拖动的方式放到指定的目标位置。当用例本身比较长时，交互上会比较繁琐。

本次mr支持在复制步骤时，选取复制步骤到当前行或者用例最后一行：

<img width="1049" alt="image" src="https://github.com/SonicCloudOrg/sonic-server/assets/15340677/eae777f3-6091-4ff5-ab35-fd57b6528da6">

已经在指定的用例步骤的上方或者下方新增加步骤：

<img width="1116" alt="image" src="https://github.com/SonicCloudOrg/sonic-server/assets/15340677/601aa32d-9676-4c37-8cf3-9de1a932986d">

主要改动点是实现了后端接口，复用了之前的排序接口，改为在新增步骤完成后，自定进行排序到指定行

