### PR TITLE
feat:用例支持按作者进行筛选的操作

### DIFF
--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/controller/TestCasesController.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/controller/TestCasesController.java
@@ -59,10 +59,10 @@ public class TestCasesController {
             @Parameter(name = "platform", description = "平台类型"),
             @Parameter(name = "name", description = "用例名称"),
             @Parameter(name = "moduleIds", description = "模块Id"),
+            @Parameter(name = "caseAuthorNames", description = "用例作者列表"),
             @Parameter(name = "page", description = "页码"),
             @Parameter(name = "pageSize", description = "页数据大小"),
             @Parameter(name = "idSort", description = "控制id排序方式"),
-            @Parameter(name = "designerSort", description = "控制designer排序方式"),
             @Parameter(name = "editTimeSort", description = "控制editTime排序方式")
 
     })
@@ -71,15 +71,16 @@ public class TestCasesController {
                                                         @RequestParam(name = "platform") int platform,
                                                         @RequestParam(name = "name", required = false) String name,
                                                         @RequestParam(name = "moduleIds[]", required = false) List<Integer> moduleIds,
+                                                        @RequestParam(name = "caseAuthorNames[]", required = false) List<String> caseAuthorNames,
                                                         @RequestParam(name = "page") int page,
                                                         @RequestParam(name = "pageSize") int pageSize,
                                                         @RequestParam(name = "idSort", required = false) String idSort,
-                                                        @RequestParam(value = "designerSort", required = false) String designerSort,
                                                         @RequestParam(value = "editTimeSort", required = false) String editTimeSort) {
         Page<TestCases> pageable = new Page<>(page, pageSize);
         return new RespModel<>(
                 RespEnum.SEARCH_OK,
-                testCasesService.findAll(projectId, platform, name, moduleIds, pageable, idSort, designerSort, editTimeSort)
+                testCasesService.findAll(projectId, platform, name, moduleIds, caseAuthorNames,
+                        pageable, idSort, editTimeSort)
         );
     }
 

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/controller/TestCasesController.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/controller/TestCasesController.java
@@ -167,4 +167,19 @@ public class TestCasesController {
         testCasesService.copyTestById(id);
         return new RespModel<>(RespEnum.COPY_OK);
     }
+
+    @WebAspect
+    @Operation(summary = "查询用例所有的作者列表", description = "查找对应项目id下对应平台的所有作者列表")
+    @Parameters(value = {
+            @Parameter(name = "projectId", description = "项目id"),
+            @Parameter(name = "platform", description = "平台类型"),
+    })
+    @GetMapping("/listAllCaseAuthor")
+    public RespModel<List<String>> findAllCaseAuthor(@RequestParam(name = "projectId") int projectId,
+                                                     @RequestParam(name = "platform") int platform) {
+        return new RespModel<>(
+                RespEnum.SEARCH_OK,
+                testCasesService.findAllCaseAuthor(projectId, platform)
+        );
+    }
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/mapper/TestCasesMapper.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/mapper/TestCasesMapper.java
@@ -22,4 +22,7 @@ public interface TestCasesMapper extends BaseMapper<TestCases> {
             "where tstc.test_suites_id = #{suiteId} " +
             "order by tstc.sort asc")
     List<TestCases> listByTestSuitesId(@Param("suiteId") int suiteId);
+
+    @Select("select DISTINCT designer from test_cases WHERE project_id= #{projectId} and platform= #{platform}")
+    List<String> listAllTestCaseAuthor(@Param("projectId") int projectId, @Param("platform") int platform);
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/TestCasesService.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/TestCasesService.java
@@ -15,8 +15,9 @@ import java.util.List;
  * @date 2021/8/20 17:51
  */
 public interface TestCasesService extends IService<TestCases> {
-    CommentPage<TestCasesDTO> findAll(int projectId, int platform, String name, List<Integer> moduleIds, Page<TestCases> pageable,
-                                      String idSort, String designerSort, String editTimeSort);
+    CommentPage<TestCasesDTO> findAll(int projectId, int platform, String name, List<Integer> moduleIds,
+                                      List<String> caseAuthorNames, Page<TestCases> pageable,
+                                      String idSort, String editTimeSort);
 
     List<TestCases> findAll(int projectId, int platform);
 

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/TestCasesService.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/TestCasesService.java
@@ -41,4 +41,13 @@ public interface TestCasesService extends IService<TestCases> {
     boolean copyTestById(int id);
 
     Boolean updateTestCaseModuleByModuleId(Integer module);
+
+    /**
+     * 查询指定项目，指定平台下，所有的用例作者列表集合
+     *
+     * @param projectId 项目id
+     * @param platform  平台
+     * @return 用例作者列表集合
+     */
+    List<String> findAllCaseAuthor(int projectId, int platform);
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestCasesServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestCasesServiceImpl.java
@@ -286,5 +286,10 @@ public class TestCasesServiceImpl extends SonicServiceImpl<TestCasesMapper, Test
         }
         return true;
     }
+
+    @Override
+    public List<String> findAllCaseAuthor(int projectId, int platform) {
+        return testCasesMapper.listAllTestCaseAuthor(projectId, platform);
+    }
 }
 

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestCasesServiceImpl.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/services/impl/TestCasesServiceImpl.java
@@ -66,20 +66,22 @@ public class TestCasesServiceImpl extends SonicServiceImpl<TestCasesMapper, Test
     private ModulesMapper modulesMapper;
 
     @Override
-    public CommentPage<TestCasesDTO> findAll(int projectId, int platform, String name, List<Integer> moduleIds, Page<TestCases> pageable,
-                                             String idSort, String designerSort, String editTimeSort) {
+    public CommentPage<TestCasesDTO> findAll(int projectId, int platform, String name, List<Integer> moduleIds,
+                                             List<String> caseAuthorNames,
+                                             Page<TestCases> pageable,
+                                             String idSort, String editTimeSort) {
 
         LambdaQueryChainWrapper<TestCases> lambdaQuery = lambdaQuery();
 
         lambdaQuery.eq(projectId != 0, TestCases::getProjectId, projectId)
                 .eq(platform != 0, TestCases::getPlatform, platform)
                 .in(moduleIds != null && moduleIds.size() > 0, TestCases::getModuleId, moduleIds)
+                .in(caseAuthorNames != null && caseAuthorNames.size() > 0, TestCases::getDesigner, caseAuthorNames)
                 .like(!StringUtils.isEmpty(name), TestCases::getName, name)
-                .orderByDesc(StringUtils.isEmpty(editTimeSort) && StringUtils.isEmpty(idSort) && StringUtils.isEmpty(designerSort),
+                .orderByDesc(StringUtils.isEmpty(editTimeSort) && StringUtils.isEmpty(idSort),
                         TestCases::getEditTime)
                 .orderBy(!StringUtils.isEmpty(editTimeSort), "asc".equals(editTimeSort), TestCases::getEditTime)
-                .orderBy(!StringUtils.isEmpty(idSort), "asc".equals(idSort), TestCases::getId)
-                .orderBy(!StringUtils.isEmpty(designerSort), "asc".equals(designerSort), TestCases::getDesigner);
+                .orderBy(!StringUtils.isEmpty(idSort), "asc".equals(idSort), TestCases::getId);
 
         //写入对应模块信息
         Page<TestCases> page = lambdaQuery.page(pageable);


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

[前端UI配套提交](https://github.com/SonicCloudOrg/sonic-client-web/pull/270)

接口做两个修改：
1.增加一个接口，用于获取当前项目指定平台下，所有的用例作者列表
2.用例筛选接口，去掉之前的按设计人排序，改为按设计人筛选
