### PR TITLE
feat: 测试步骤分组自由拖拽

### DIFF
--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/http/StepSort.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/http/StepSort.java
@@ -24,15 +24,15 @@ public class StepSort implements Serializable {
     private Integer newParentId;
     @Schema(description = "更换分组后在新分组中新的index", required = false, example = "1")
     private Integer newIndex;
-    @Schema(description = "移动步骤的sort序号", required = false, example = "1")
-    private Integer thisSort;
+    @Schema(description = "被移动步骤的主键id", required = false, example = "1")
+    private Integer stepsId;
 
-    public Integer getThisSort() {
-        return thisSort;
+    public Integer getStepsId() {
+        return stepsId;
     }
 
-    public void setThisSort(Integer thisSort) {
-        this.thisSort = thisSort;
+    public void setStepsId(Integer stepsId) {
+        this.stepsId = stepsId;
     }
 
     public Integer getNewIndex() {
@@ -92,7 +92,7 @@ public class StepSort implements Serializable {
                 ", endId=" + endId +
                 ", newParentId=" + newParentId +
                 ", newIndex=" + newIndex +
-                ", thisSort=" + thisSort +
+                ", stepsId=" + stepsId +
                 '}';
     }
 }

--- a/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/http/StepSort.java
+++ b/sonic-server-controller/src/main/java/org/cloud/sonic/controller/models/http/StepSort.java
@@ -20,6 +20,36 @@ public class StepSort implements Serializable {
     @Positive
     @Schema(description = "移动后被影响的最后一个步骤sort序号", required = true, example = "9")
     private int endId;
+    @Schema(description = "移动步骤发生分组更改的新parentId", required = false, example = "1")
+    private Integer newParentId;
+    @Schema(description = "更换分组后在新分组中新的index", required = false, example = "1")
+    private Integer newIndex;
+    @Schema(description = "移动步骤的sort序号", required = false, example = "1")
+    private Integer thisSort;
+
+    public Integer getThisSort() {
+        return thisSort;
+    }
+
+    public void setThisSort(Integer thisSort) {
+        this.thisSort = thisSort;
+    }
+
+    public Integer getNewIndex() {
+        return newIndex;
+    }
+
+    public void setNewIndex(Integer newIndex) {
+        this.newIndex = newIndex;
+    }
+
+    public Integer getNewParentId() {
+        return newParentId;
+    }
+
+    public void setNewParentId(Integer newParentId) {
+        this.newParentId = newParentId;
+    }
 
     public int getCaseId() {
         return caseId;
@@ -60,6 +90,9 @@ public class StepSort implements Serializable {
                 ", direction='" + direction + '\'' +
                 ", startId=" + startId +
                 ", endId=" + endId +
+                ", newParentId=" + newParentId +
+                ", newIndex=" + newIndex +
+                ", thisSort=" + thisSort +
                 '}';
     }
 }


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

- 不同分组拖拽后排序，原有的方式只支持同个分组内重新排序，这个pr是增加一个判断如果是跨组拖拽，更新被拖拽步骤的parentId以及仅对新的分组内受影响的sort进行排序
- 对应前端：https://github.com/SonicCloudOrg/sonic-client-web/pull/288
